### PR TITLE
Convert kWh gas unit to m3 for HA energy monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Home Assistant integration for energy consumption data from UK SMETS (Smart) met
 
 This integration works without requiring a consumer device provided by Hildebrand Glow and can work with your existing smart meter. You'll need to set up your smart meter for free in the Bright app on [Android](https://play.google.com/store/apps/details?id=uk.co.hildebrand.brightionic&hl=en_GB) or [iOS](https://apps.apple.com/gb/app/bright/id1369989022). This will only work when using the Data Communications Company (DCC) backend, which all SMETS 2 meters and some SMETS 1 meters do ([more information](https://www.smartme.co.uk/technical.html)). Once you can see your data in the app, you are good to go.
 
-If you are using [Hildebrand Glow hardware](https://shop.glowmarkt.com/), you should use the MQTT version [here](https://github.com/unlobito/ha-hildebrandglow/tree/mqtt) to get current consumption data.
+The data provided will be delayed by around 30 minutes. To get real-time consumption data, you can buy [Hildebrand Glow hardware](https://shop.glowmarkt.com/). Although this integration will work with their hardware, you should use the MQTT version [here](https://github.com/unlobito/ha-hildebrandglow/tree/mqtt) to get real-time consumption data.
 
 This integration will currently emit one sensor for the daily usage of each detected smart meter.
 
@@ -51,10 +51,10 @@ python -m venv dev-venv
 . dev-venv\Scripts\activate
 ```
 
-You can then install the dependencies that will allow you to run tests:
+You can then install the dependencies that will allow you to develop:
 `pip3 install -r requirements-dev.txt`
 
-This will install `homeassistant`, `autopep8`, `isort` and `pylint`, a plugin which allows you to leverage helpers that are available in Home Assistant for core integration tests.
+This will install `homeassistant`, `autopep8`, `isort` and `pylint`.
 
 ### Code Style
 

--- a/custom_components/hildebrandglow_dcc/const.py
+++ b/custom_components/hildebrandglow_dcc/const.py
@@ -1,4 +1,4 @@
 """Constants for the Hildebrand Glow integration."""
 
-DOMAIN = "hildebrandglow_dcc"
+DOMAIN = "hildebrandglow_gas"
 APP_ID = "b0f1b774-a586-4f72-9edd-27ead8aa7a8d"

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -6,5 +6,5 @@
   "issue_tracker": "https://github.com/jake-armour/ha-hildebrandglow/issues",
   "codeowners": ["@jake-armour"],
   "iot_class": "cloud_polling",
-  "version": "0.4.1"
+  "version": "0.4.2"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -6,5 +6,5 @@
   "issue_tracker": "https://github.com/jake-armour/ha-hildebrandglow/issues",
   "codeowners": ["@jake-armour"],
   "iot_class": "cloud_polling",
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -4,13 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/HandyHat/ha-hildebrandglow",
   "issue_tracker": "https://github.com/HandyHat/ha-hildebrandglow/issues",
-  "requirements": ["pytz"],
-  "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
-  "dependencies": [],
   "codeowners": ["@handyhat"],
   "iot_class": "cloud_polling",
-  "version": "0.3.2"
-
+  "version": "0.3.3"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -6,5 +6,5 @@
   "issue_tracker": "https://github.com/jake-armour/ha-hildebrandglow/issues",
   "codeowners": ["@jake-armour"],
   "iot_class": "cloud_polling",
-  "version": "0.4.4"
+  "version": "0.4.5"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -6,5 +6,5 @@
   "issue_tracker": "https://github.com/jake-armour/ha-hildebrandglow/issues",
   "codeowners": ["@jake-armour"],
   "iot_class": "cloud_polling",
-  "version": "0.4.3"
+  "version": "0.4.4"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -1,10 +1,10 @@
 {
-  "domain": "hildebrandglow_dcc",
-  "name": "Hildebrand Glow (DCC)",
+  "domain": "hildebrandglow_gas",
+  "name": "Hildebrand Glow (Plus Gas)",
   "config_flow": true,
-  "documentation": "https://github.com/HandyHat/ha-hildebrandglow",
-  "issue_tracker": "https://github.com/HandyHat/ha-hildebrandglow/issues",
-  "codeowners": ["@handyhat"],
+  "documentation": "https://github.com/jake-armour/ha-hildebrandglow",
+  "issue_tracker": "https://github.com/jake-armour/ha-hildebrandglow/issues",
+  "codeowners": ["@jake-armour"],
   "iot_class": "cloud_polling",
-  "version": "0.3.3"
+  "version": "0.4.0"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -6,5 +6,5 @@
   "issue_tracker": "https://github.com/jake-armour/ha-hildebrandglow/issues",
   "codeowners": ["@jake-armour"],
   "iot_class": "cloud_polling",
-  "version": "0.4.2"
+  "version": "0.4.3"
 }

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -142,9 +142,8 @@ class GlowConsumptionCurrent(SensorEntity):
                 Glow.handle_failed_auth(ConfigEntry, HomeAssistant)
         else:
             try:
-                amount = float(self.glow.current_usage) / 10.55
                 self.state = await self.hass.async_add_executor_job(
-                    amount, self.resource["resourceId"]
+                    float(self.glow.current_usage)/10.55, self.resource["resourceId"]
                 )
             except InvalidAuth:
                 Glow.handle_failed_auth(ConfigEntry, HomeAssistant)

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Optional
 import pytz
 from homeassistant.components.sensor import (
     DEVICE_CLASS_ENERGY,
-    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -58,7 +58,7 @@ class GlowConsumptionCurrent(SensorEntity):
 
     available = True
 
-    _attr_state_class = STATE_CLASS_MEASUREMENT
+    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
 
     def __init__(self, glow: Glow, resource: Dict[str, Any]):
         """Initialize the sensor."""
@@ -119,16 +119,6 @@ class GlowConsumptionCurrent(SensorEntity):
         if self._state is not None and self._state["units"] == "kWh":
             return ENERGY_KILO_WATT_HOUR
         return None
-
-    @property
-    def last_reset(self):
-        "Returns midnight for current day"
-        tz = pytz.timezone("Europe/London")  # choose timezone
-        # Get correct date for the midnight using given timezone.
-        today = datetime.now(tz).date()
-        # Get midnight in the correct timezone (taking into account DST)
-        midnight = tz.localize(datetime.combine(today, time(0, 0)), is_dst=None)
-        return midnight
 
     async def async_update(self) -> None:
         """Fetch new state data for the sensor.

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -112,7 +112,7 @@ class GlowConsumptionCurrent(SensorEntity):
             if self.resource["dataSourceResourceTypeInfo"]["type"] == "ELEC":
                 return self._state["data"][0][1]
             elif self.resource["dataSourceResourceTypeInfo"]["type"] == "GAS":
-                return float(self._state["data"][0][1])/10.55
+                return float(self._state["data"][0][1]) * 3.6 / 40 / 1.02264 
         return None
 
     @property

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -133,9 +133,18 @@ class GlowConsumptionCurrent(SensorEntity):
 
         This is the only method that should fetch new data for Home Assistant.
         """
-        try:
-            self._state = await self.hass.async_add_executor_job(
-                self.glow.current_usage, self.resource["resourceId"]
-            )
-        except InvalidAuth:
-            Glow.handle_failed_auth(ConfigEntry, HomeAssistant)
+        if self.resource["dataSourceResourceTypeInfo"]["type"] == "ELEC":
+            try:
+                self._state = await self.hass.async_add_executor_job(
+                    self.glow.current_usage, self.resource["resourceId"]
+                )
+            except InvalidAuth:
+                Glow.handle_failed_auth(ConfigEntry, HomeAssistant)
+        else:
+            try:
+                amount = float(self.glow.current_usage) / 10.55
+                self.state = await self.hass.async_add_executor_job(
+                    amount, self.resource["resourceId"]
+                )
+            except InvalidAuth:
+                Glow.handle_failed_auth(ConfigEntry, HomeAssistant)

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -5,11 +5,15 @@ from typing import Any, Callable, Dict, Optional
 import pytz
 from homeassistant.components.sensor import (
     DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_GAS,
     STATE_CLASS_TOTAL_INCREASING,
     SensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENERGY_KILO_WATT_HOUR
+from homeassistant.const import (
+    ENERGY_KILO_WATT_HOUR,
+    VOLUME_CUBIC_METERS
+)
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
@@ -110,14 +114,18 @@ class GlowConsumptionCurrent(SensorEntity):
 
     @property
     def device_class(self) -> str:
-        """Return the device class (always DEVICE_CLASS_ENERGY)."""
-        return DEVICE_CLASS_ENERGY
+        if self.resource["dataSourceResourceTypeInfo"]["type"] == "ELEC":
+            return DEVICE_CLASS_ENERGY
+        elif self.resource["dataSourceResourceTypeInfo"]["type"] == "GAS":
+            return DEVICE_CLASS_GAS
 
     @property
     def unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement."""
-        if self._state is not None and self._state["units"] == "kWh":
+        if self.resource["dataSourceResourceTypeInfo"]["type"] == "ELEC":
             return ENERGY_KILO_WATT_HOUR
+        elif self.resource["dataSourceResourceTypeInfo"]["type"] == "GAS":
+            return VOLUME_CUBIC_METERS
         return None
 
     async def async_update(self) -> None:

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
     "render_readme": true,
     "domains": ["sensor"],
     "country": ["GB"],
-    "homeassistant": "2021.9.0"
+    "homeassistant": "2021.9.2"
   }

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,6 @@
     "name": "Hildebrand Glow (DCC)",
     "render_readme": true,
     "domains": ["sensor"],
-    "country": ["GB"]
+    "country": ["GB"],
+    "homeassistant": "2021.9.0"
   }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Hildebrand Glow (DCC)",
+    "name": "Hildebrand Glow (Gas)",
     "render_readme": true,
     "domains": ["sensor"],
     "country": ["GB"],

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 autopep8==1.5.7
-homeassistant==2021.8.8
+homeassistant==2021.9.0
 isort==5.9.3
 pylint==2.9.6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fork converts the kWh energy value received by the smart meter (and therefore into Glow) into m3 which is the value that Home Assistant has decided to make the default for gas monitoring inside of their energy monitoring dashboard. Gas tracking was added in 2021.9.0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change allows for the state of the gas entity inside of Hildebrand Glow to be converted into a value that Home Assistant recognises as a gas measurement. This allows it to be added to the energy monitoring dashboard as gas consumption rather than an extension of the energy consumption.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested on my personal home assistant install and has been running for the past few days. I have kept the original install active and checked the values that it receives to ensure that, after conversion, they match with the converted values. The only parts of this code that it changes are the addition of cubic meters as a measurement (from home assistant constants) and the update to the state, including adding a filter for gas/electricity in the state set and then applying the conversion inside the gas filter. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
