### PR TITLE
Improved error handling when Tariff data unavailable & other minor enhancements.

### DIFF
--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -180,11 +180,12 @@ class GlowUsage(SensorEntity):
                 return round(res, 3)
             except (KeyError, IndexError, TypeError) as _error:
                 if self.data_error_logged:
-                    return None
+                    return GLOW_DATA_UNAVAILABLE
+
                 self.data_error_logged = True
                 _LOGGER.error("Glow API data error (%s): (%s)",
                               self.name, _error)
-                return None
+                return GLOW_DATA_UNAVAILABLE
 
         if not self.initialised:
             return GLOW_STARTING

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -328,8 +328,8 @@ class GlowStanding(GlowUsage):
         if self.backoff > 1:
             self.backoff -= 1
             return
-        elif self.backoff == 1:
-            self.backoff = 0
+        
+        self.backoff = 0
 
         await self._glow_update(self.glow.current_tariff)
 

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -260,7 +260,7 @@ class GlowStanding(GlowUsage):
         super().__init__(glow, resource, config)
         self._attr_state_class = STATE_CLASS_MEASUREMENT
         self.backoff = 0
-        self.available = False
+        self.tariff_available = False
 
     @property
     def unique_id(self) -> str:
@@ -290,7 +290,7 @@ class GlowStanding(GlowUsage):
                 plan = self._state["data"][0]["currentRates"]
                 standing = plan["standingCharge"]
                 standing = float(standing) / 100
-                self.available = True
+                self.tariff_available = True
                 return standing
 
             except (KeyError, IndexError, TypeError):
@@ -299,7 +299,7 @@ class GlowStanding(GlowUsage):
 
                 self.data_error_logged = True
 
-                if self.available:  # Has data ever been available?
+                if self.tariff_available:  # Has data ever been available?
                     self.backoff = BACKOFF_HOUR
                 else:
                     self.backoff = BACKOFF_DAY

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -325,9 +325,11 @@ class GlowStanding(GlowUsage):
 
         This is the only method that should fetch new data for Home Assistant.
         """
-        self.backoff -= 1
-        if self.backoff > 0:
+        if self.backoff > 1:
+            self.backoff -= 1
             return
+        elif self.backoff == 1:
+            self.backoff = 0
 
         await self._glow_update(self.glow.current_tariff)
 

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -24,7 +24,7 @@ SCAN_INTERVAL = timedelta(minutes=2)
 
 BACKOFF_HOUR = 30  # Updates once every 2 minutes by default.
 BACKOFF_DAY = BACKOFF_HOUR * 24
-GLOW_STARTING = "Staring..."
+GLOW_STARTING = "Starting..."
 GLOW_DATA_UNAVAILABLE = "Unavailable"
 
 

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -1,4 +1,5 @@
 """Platform for sensor integration."""
+import asyncio
 import logging
 from datetime import timedelta
 from typing import Any, Callable, Dict, Optional
@@ -329,10 +330,8 @@ class GlowStanding(GlowUsage):
             self.backoff -= 1
             return
         
-        self.backoff = 0
-
         await self._glow_update(self.glow.current_tariff)
-
+        self.backoff = 0
 
 class GlowRate(GlowStanding):
     """Sensor object for the Glowmarkt resource's current unit tariff."""
@@ -396,5 +395,6 @@ class GlowRate(GlowStanding):
 
     async def async_update(self) -> None:
         """Fetch new state data for the sensor."""
+        await asyncio.sleep(2)  # give standing rate sensor time to update
         self._state = self.buddy.rawdata
         self.initialised = self.buddy.initialised

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -258,6 +258,7 @@ class GlowStanding(GlowUsage):
         super().__init__(glow, resource, config)
         self._attr_state_class = STATE_CLASS_MEASUREMENT
         self.backoff = 0
+        self.available = False
 
     @property
     def unique_id(self) -> str:
@@ -287,6 +288,7 @@ class GlowStanding(GlowUsage):
                 plan = self._state["data"][0]["currentRates"]
                 standing = plan["standingCharge"]
                 standing = float(standing) / 100
+                self.available = True
                 return standing
 
             except (KeyError, IndexError, TypeError):
@@ -295,7 +297,7 @@ class GlowStanding(GlowUsage):
 
                 self.data_error_logged = True
 
-                if self.initialised:
+                if self.available:  # Has data ever been available?
                     self.backoff = BACKOFF_HOUR
                 else:
                     self.backoff = BACKOFF_DAY

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -209,17 +209,14 @@ class GlowUsage(SensorEntity):
             if not ((0 <= minutes <= 2) or (30 <= minutes <= 32)):
                 # only need to update one per every 30 minutes
                 # anything else Glow will ignore
-                _LOGGER.debug("Ignoring poll - outside time window")
                 return
 
         self.initialised = True
 
         try:
-            _LOGGER.debug("getting data")
             self._state = await self.hass.async_add_executor_job(
                 func, self.resource["resourceId"]
             )
-            _LOGGER.debug("got data")
 
         except InvalidAuth:
             _LOGGER.debug("calling auth failed 2")

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -325,8 +325,8 @@ class GlowStanding(GlowUsage):
 
         This is the only method that should fetch new data for Home Assistant.
         """
+        self.backoff -= 1
         if self.backoff > 0:
-            self.backoff -= 1
             return
 
         await self._glow_update(self.glow.current_tariff)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR contains the following enhancements:
- If Tariff data is unavailable (as indicated as a failure to ever retrieve data), rather than retry every 2 minutes (which will repeatedly fail), it backs off to trying once per day.
- If Tariff data is temporarily unavailable (indicated by data having been previously been retrieved), there is no change to behaviour.
- When data is not available the sensor status is set to "unavailable" instead of "unknown".
- Reading  the Tariff rate data waits for 2 seconds to allow the data to arrive from the buddy Standing Rate sensor.  Without this the Tariff rate data is always one update cycle out of date (2 minutes),

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enhancements

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run in local test and live environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
