### PR TITLE
Update sensor to only query Glow API shortly after 0 and 30 mins past the hour

### DIFF
--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -22,7 +22,7 @@ from .glow import Glow, InvalidAuth
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(minutes=1)
+SCAN_INTERVAL = timedelta(minutes=2)
 
 
 async def async_setup_entry(
@@ -200,14 +200,13 @@ class GlowUsage(SensorEntity):
     async def _glow_update(self, func: Callable) -> None:
         sleepdelay = (random.randint(0,120))
         minutes = datetime.now().minute
-        if (0 <= minutes <= 5) or (30 <= minutes <= 35):
+        if (0 <= minutes <= 2) or (30 <= minutes <= 32):
             _LOGGER.debug(f"Update time, sleeping {sleepdelay} before talking to API")
             await asyncio.sleep(sleepdelay)
             try:
                 self._state = await self.hass.async_add_executor_job(
                     func, self.resource["resourceId"]
                 )
-                await asyncio.sleep(300)
             except InvalidAuth:
                 _LOGGER.debug("calling auth failed 2")
                 await Glow.handle_failed_auth(self.config, self.hass)

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -1,6 +1,6 @@
 """Platform for sensor integration."""
 import logging
-from datetime import datetime,timedelta
+from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, Optional
 import random
 import asyncio
@@ -198,7 +198,7 @@ class GlowUsage(SensorEntity):
 
     async def _glow_update(self, func: Callable) -> None:
         """Get updated data from Glow"""
-        sleepdelay = (random.randint(0,120))
+        sleepdelay = (random.randint(0, 120))
         minutes = datetime.now().minute
         if (0 <= minutes <= 2) or (30 <= minutes <= 32):
             _LOGGER.debug(f"Update time, sleeping {sleepdelay}s before talking to API")

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -3,7 +3,6 @@ import logging
 from datetime import datetime,timedelta
 from typing import Any, Callable, Dict, Optional
 import random
-from time import sleep
 import asyncio
 
 from homeassistant.components.sensor import (

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -198,7 +198,7 @@ class GlowUsage(SensorEntity):
 
     async def _glow_update(self, func: Callable) -> None:
         """Get updated data from Glow"""
-        sleepdelay = (random.randint(0, 120))
+        sleepdelay = (random.randint(60, 180))
         minutes = datetime.now().minute
         if (0 <= minutes <= 2) or (30 <= minutes <= 32):
             _LOGGER.debug(f"Update time, sleeping {sleepdelay}s before talking to API")

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -198,6 +198,7 @@ class GlowUsage(SensorEntity):
         return None
 
     async def _glow_update(self, func: Callable) -> None:
+        """Get updated data from Glow"""
         sleepdelay = (random.randint(0,120))
         minutes = datetime.now().minute
         if (0 <= minutes <= 2) or (30 <= minutes <= 32):
@@ -210,10 +211,6 @@ class GlowUsage(SensorEntity):
             except InvalidAuth:
                 _LOGGER.debug("calling auth failed 2")
                 await Glow.handle_failed_auth(self.config, self.hass)
-        else:
-            _LOGGER.debug(f"Not time to update")
-        """Get updated data from Glow"""
-        
 
     async def async_update(self) -> None:
         """Fetch new state data for the sensor.

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -201,7 +201,7 @@ class GlowUsage(SensorEntity):
         sleepdelay = (random.randint(0,120))
         minutes = datetime.now().minute
         if (0 <= minutes <= 2) or (30 <= minutes <= 32):
-            _LOGGER.debug(f"Update time, sleeping {sleepdelay} before talking to API")
+            _LOGGER.debug(f"Update time, sleeping {sleepdelay}s before talking to API")
             await asyncio.sleep(sleepdelay)
             try:
                 self._state = await self.hass.async_add_executor_job(


### PR DESCRIPTION
This is to address Glow's concerns referenced in https://github.com/HandyHat/ha-hildebrandglow-dcc/issues/126

There's probably a better way to do this, but it seems to work. I'm new to HA development so finding my feet a little.

This does cause HA to complain that the sensor update is taking over 10s, but doesn't seem to be a problem

```
Feb 08 18:30:00 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:00 DEBUG (MainThread) [custom_components.hildebrandglow_dcc.sensor] Update time, sleeping 22 before talking to API
Feb 08 18:30:00 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:00 DEBUG (MainThread) [custom_components.hildebrandglow_dcc.sensor] Update time, sleeping 30 before talking to API
Feb 08 18:30:00 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:00 DEBUG (MainThread) [custom_components.hildebrandglow_dcc.sensor] Update time, sleeping 77 before talking to API
Feb 08 18:30:00 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:00 DEBUG (MainThread) [custom_components.hildebrandglow_dcc.sensor] Update time, sleeping 2 before talking to API
Feb 08 18:30:00 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:00 DEBUG (MainThread) [custom_components.hildebrandglow_dcc.sensor] Update time, sleeping 7 before talking to API
Feb 08 18:30:00 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:00 DEBUG (MainThread) [custom_components.hildebrandglow_dcc.sensor] Update time, sleeping 15 before talking to API
Feb 08 18:30:00 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:00 DEBUG (MainThread) [custom_components.hildebrandglow_dcc.sensor] Update time, sleeping 21 before talking to API
Feb 08 18:30:00 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:00 DEBUG (MainThread) [custom_components.hildebrandglow_dcc.sensor] Update time, sleeping 39 before talking to API
Feb 08 18:30:02 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:02 DEBUG (SyncWorker_1) [custom_components.hildebrandglow_dcc.glow] get 2: (https://api.glowmarkt.com/api/v0-1/resource/XXXX/readings?from=2022-02-08T00:00:00&to=2022-02-08T23:59:59&period=P1D&offset=0&function=sum)
Feb 08 18:30:07 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:07 DEBUG (SyncWorker_0) [custom_components.hildebrandglow_dcc.glow] get 2: (https://api.glowmarkt.com/api/v0-1/resource/XXXX/readings?from=2022-01-01T00:00:00&to=2022-02-08T23:59:59&period=P1Y&offset=0&function=sum)
Feb 08 18:30:10 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:10 WARNING (MainThread) [homeassistant.helpers.entity] Update of sensor.gas_consumption_today is taking over 10 seconds
Feb 08 18:30:10 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:10 WARNING (MainThread) [homeassistant.helpers.entity] Update of sensor.gas_consumption_year is taking over 10 seconds
Feb 08 18:30:10 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:10 WARNING (MainThread) [homeassistant.helpers.entity] Update of sensor.gas_tariff_standing is taking over 10 seconds
Feb 08 18:30:10 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:10 WARNING (MainThread) [homeassistant.helpers.entity] Update of sensor.electric_tariff_standing is taking over 10 seconds
Feb 08 18:30:10 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:10 WARNING (MainThread) [homeassistant.helpers.entity] Update of sensor.gas_cost_today is taking over 10 seconds
Feb 08 18:30:10 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:10 WARNING (MainThread) [homeassistant.helpers.entity] Update of sensor.electric_cost_today is taking over 10 seconds
Feb 08 18:30:15 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:15 DEBUG (SyncWorker_0) [custom_components.hildebrandglow_dcc.glow] get 2: (https://api.glowmarkt.com/api/v0-1/resource/XXXX/tariff)
Feb 08 18:30:21 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:21 DEBUG (SyncWorker_0) [custom_components.hildebrandglow_dcc.glow] get 2: (https://api.glowmarkt.com/api/v0-1/resource/XXXX/readings?from=2022-02-08T00:00:00&to=2022-02-08T23:59:59&period=P1D&offset=0&function=sum)
Feb 08 18:30:22 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:22 DEBUG (SyncWorker_5) [custom_components.hildebrandglow_dcc.glow] get 2: (https://api.glowmarkt.com/api/v0-1/resource/XXXX/readings?from=2022-02-08T00:00:00&to=2022-02-08T23:59:59&period=P1D&offset=0&function=sum)
Feb 08 18:30:30 HA 62d3ea2a38d1[1066]: 2022-02-08 18:30:30 DEBUG (SyncWorker_6) [custom_components.hildebrandglow_dcc.glow] get 2: (https://api.glowmarkt.com/api/v0-1/resource/XXXX/readings?from=2022-01-01T00:00:00&to=2022-02-08T23:59:59&period=P1Y&offset=0&function=sum)
```