### PR TITLE
Updated Hildebrand API documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Thanks go to:
 
 - The [pyglowmarkt](https://github.com/cybermaggedon/pyglowmarkt) library, which is used to interact with the Hildebrand API.
 
-- The Hildebrand API [documentation](https://docs.glowmarkt.com/GlowmarktAPIDataRetrievalDocumentationIndividualUserForBright.pdf) and [Swagger UI](https://api.beething.com/api-docs/v0-1/resourcesys/).
+- The Hildebrand API [documentation](https://docs.glowmarkt.com/GlowmarktAPIDataRetrievalDocumentationIndividualUserForBright.pdf) and [Swagger UI](https://api.glowmarkt.com/api-docs/v0-1/resourcesys/).
 
 - The [original project](https://github.com/unlobito/ha-hildebrandglow) from which this project is forked.
 


### PR DESCRIPTION
Incorrect url, https://api.beething.com/api-docs/v0-1/resourcesys/ results in a timeout. Updating as per Hildebrand documentation.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Cosmetic update to readme

## Motivation and Context
Correct documentation

## How Has This Been Tested?
Clicking now directs you to their SwaggerUI.

## Types of changes
Documentation Update
