### PR TITLE
Sum the second value returned from pyglowmarkt if it exist.

### DIFF
--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -176,11 +176,16 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
             _LOGGER.exception("Unexpected exception: %s. Please open an issue", ex)
 
     try:
+        _LOGGER.debug("Get readings from %s to %s for %s", t_from, t_to, resource.classifier)
         readings = await hass.async_add_executor_job(
             resource.get_readings, t_from, t_to, "P1D", "sum", True
         )
         _LOGGER.debug("Successfully got daily usage for resource id %s", resource.id)
-        return readings[0][1].value
+        _LOGGER.debug("Readings for %s has %s entries", resource.classifier, len(readings))
+        v = readings[0][1].value
+        if len(readings) > 1:
+            v += readings[1][1].value
+        return v
     except requests.Timeout as ex:
         _LOGGER.error("Timeout: %s", ex)
     except requests.exceptions.ConnectionError as ex:


### PR DESCRIPTION
## Description
A change in how pyglowmarkt handles timezones causes two values to be returned most of the times instead of a single value.

## Motivation and Context
The above change in pyglowmarkt was not reflected and only the first value was used, which only contained data from the first our of the day.  This is described in issue #330 and this PR fixes the issue.

## How Has This Been Tested?
The fix has been tested on my own live system.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
