### PR TITLE
Ensure that should_update only triggers in minutes 1-5 and 31-35 past the hour

### DIFF
--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -134,9 +134,9 @@ def device_name(resource, virtual_entity) -> str:
 
 
 async def should_update() -> bool:
-    """Check if time is between 0-5 or 30-35 minutes past the hour."""
+    """Check if time is between 1-5 or 31-35 minutes past the hour."""
     minutes = datetime.now().minute
-    if (0 <= minutes <= 5) or (30 <= minutes <= 35):
+    if (1 <= minutes <= 5) or (31 <= minutes <= 35):
         return True
     return False
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed should_update trigger to only trigger twice an hour

## Motivation and Context
The current code allows triggers twice in six minutes if the sequence is 0,5,10,15...55 at 0,5,30, & 35 minutes past the hour
Fixes issue [#361 ](https://github.com/HandyHat/ha-hildebrandglow-dcc/issues/361)

## How Has This Been Tested?
Change the code on my running system and restarted exactly on the hour. Before the change, four runs an hour, afterwards two runs an hour
Checked  by reviewing the logs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
