### PR TITLE
Setup robustness

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: JonandEl
-custom: "https://www.buymeacoffee.com/HandyHat"
+custom: "https://www.buymeacoffee.com/jonandel"

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: HandyHat
+github: JonandEl
 custom: "https://www.buymeacoffee.com/HandyHat"

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: JonandEl
+github: jonandel
 custom: "https://www.buymeacoffee.com/jonandel"

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,6 +23,7 @@ A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
+Particularly if you are using gas and electricity monitoring.
 
 **Version**
 What version of the integration and what version of Home Assistant are you running?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+        - uses: "actions/checkout@v4"
+        - uses: "home-assistant/actions/hassfest@master"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4.2.2
       - name: HACS Validation
         uses: "hacs/action@22.5.0"
         with:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Harley Watson
+Copyright (c) 2025 Jon Bartlett - but note many others have contributed to this multiple forked solun
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@
 
 Home Assistant integration for energy consumption data from UK SMETS (Smart) meters using the Hildebrand Glow API.
 
-Abandoned: At the moment, this project should be considered abandoned. I do intend to come back to this project at some point, but issues with my own smart meters along with other priorities have meant I haven't kept up with the many changes from Hildebrand's side and from Home Assistant's side, and so this project really needs a complete rewrite which I don't have the time to complete at the moment. Please do not expect this integration to work.
-
-This integration works without requiring a consumer device provided by Hildebrand Glow and can work with your existing smart meter. You'll need to set up your smart meter for free in the Bright app on [Android](https://play.google.com/store/apps/details?id=uk.co.hildebrand.brightionic&hl=en_GB) or [iOS](https://apps.apple.com/gb/app/bright/id1369989022). This will only work when using the Data Communications Company (DCC) backend, which all [SMETS 2 meters](https://www.smartme.co.uk/smets-2.html) and some [SMETS 1 meters](https://www.smartme.co.uk/smets-1.html) do. Once you can see your data in the app, you are good to go.
-
-The data provided will be delayed by around 30 minutes. To get real-time consumption data, you can buy [Hildebrand Glow hardware](https://shop.glowmarkt.com/). Although this integration will technically work with their hardware, you should instead use the [Local MQTT integration](https://github.com/megakid/ha_hildebrand_glow_ihd_mqtt) or the [Cloud MQTT integration](https://github.com/unlobito/ha-hildebrandglow/) to get real-time consumption data which is not delayed.
+The original of this project is now declared as abandoned, so after the local tweaks Ive been making over the last 24 months, and into the future, I decided to create my own fork.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The original from (HandyHat) of this project is now declared as abandoned, so af
 
 You can install this component through [HACS](https://hacs.xyz/) to easily receive updates. Once HACS is installed, click this link:
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Jonandel&repository=ha-hildebrandglow-dcc)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jonandel&repository=ha-hildebrandglow-dcc)
 
 <details>
   <summary>Manually add to HACS</summary>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Hildebrand Glow (DCC) Integration
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
-[![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/HandyHat/ha-hildebrandglow-dcc?style=for-the-badge)](https://www.codefactor.io/repository/github/handyhat/ha-hildebrandglow-dcc)
-[![DeepSource](https://deepsource.io/gh/HandyHat/ha-hildebrandglow-dcc.svg/?label=active+issues&show_trend=true&token=gYN6CNb5ApHN5Pry_U-FFSYK)](https://deepsource.io/gh/HandyHat/ha-hildebrandglow-dcc/?ref=repository-badge)
-[!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/HandyHat)
+[![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/JonandEl/ha-hildebrandglow-dcc?style=for-the-badge)](https://www.codefactor.io/repository/github/handyhat/ha-hildebrandglow-dcc)
+[![DeepSource](https://deepsource.io/gh/HandyHat/ha-hildebrandglow-dcc.svg/?label=active+issues&show_trend=true&token=gYN6CNb5ApHN5Pry_U-FFSYK)](https://deepsource.io/gh/JonandEl/ha-hildebrandglow-dcc/?ref=repository-badge)
+[!["Buy the original author A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/HandyHat)
 
 Home Assistant integration for energy consumption data from UK SMETS (Smart) meters using the Hildebrand Glow API.
 The original from (HandyHat) of this project is now declared as abandoned, so after the local tweaks Ive been making over the last 24 months, and into the future, I decided to create my own fork.

--- a/README.md
+++ b/README.md
@@ -97,12 +97,8 @@ This project makes use of black, isort and pylint to enforce a consistent code s
 
 Thanks go to:
 
-- The [pyglowmarkt](https://github.com/cybermaggedon/pyglowmarkt) library, which is used to interact with the Hildebrand API.
-
 - The Hildebrand API [documentation](https://docs.glowmarkt.com/GlowmarktAPIDataRetrievalDocumentationIndividualUserForBright.pdf) and [Swagger UI](https://api.glowmarkt.com/api-docs/v0-1/resourcesys/).
 
-- The [original project](https://github.com/unlobito/ha-hildebrandglow) from which this project is forked.
-
-- The [Hildebrand-Glow-Python-Library](https://github.com/ghostseven/Hildebrand-Glow-Python-Library), used for understanding the API.
+- The [original project](https://github.com/HandyHat/ha-hildebrandglow) from which this project is forked.
 
 - All of the contributors and users, without whom this integration wouldn't be where it is today.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 [![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/JonandEl/ha-hildebrandglow-dcc?style=for-the-badge)](https://www.codefactor.io/repository/github/jonandel/ha-hildebrandglow-dcc)
 [![DeepSource](https://deepsource.io/gh/jonandel/ha-hildebrandglow-dcc.svg/?label=active+issues&show_trend=true&token=gYN6CNb5ApHN5Pry_U-FFSYK)](https://deepsource.io/gh/JonandEl/ha-hildebrandglow-dcc/?ref=repository-badge)
-[!["Buy the original author A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/HandyHat)
+[!["Buy the author A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/jonandel)
 
 Home Assistant integration for energy consumption data from UK SMETS (Smart) meters using the Hildebrand Glow API.
 The original from (HandyHat) of this project is now declared as abandoned, so after the local tweaks Ive been making over the last 24 months, and into the future, I decided to create my own fork.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [!["Buy the author A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/jonandel)
 
 Home Assistant integration for energy consumption data from UK SMETS (Smart) meters using the Hildebrand Glow API.
-The original from (HandyHat) of this project is now declared as abandoned, so after the local tweaks Ive been making over the last 24 months, and into the future, I decided to create my own fork.
+The original from (HandyHat) of this project is now declared as abandoned, so after the local tweaks Ive been making over the last 24 months, and into the future, I decided to create my own fork, and release it.
+The idea is that this new Repo will be a place where the community of users can contribute, and collectively we can improve this Integration.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ If the data being shown is wrong, check the Bright app first. If it is also wron
 
 ## Energy Management
 
-The sensors created integrate directly into Home Assistant's [Home Energy Management](https://www.home-assistant.io/docs/energy/).
-It is recommended you use the daily usage and cost sensors in the Energy integration.
-However, be aware that due to the lower refresh rate of this Integration, you will need to wait until the sensors have data, before you can add/edit them into the Energy dashboard (they will have an indepterminate state before that) - so wait an hour or two.
+The sensors created were originally designed to integrate directly into Home Assistant's [Home Energy Management](https://www.home-assistant.io/docs/energy/).  However, with HA since (roughly 2024), the energy dashboard does not handle the daily resetting of the sensors.  
+It is NOT recommended you use the daily usage and cost sensors in the Energy integration, and consider using the Utility Meter Integration (built into HA), and define you own total usage and Cost sensors.  A later release of this integration will update on suggestions on what and how to do this - but it is currently believed to be NOT something this integration can resolve directly.
+
+Be aware also that due to the lower refresh rate of this Integration, you will need to wait until the sensors have data - so wait an hour or two.
 
 [![Open your Home Assistant instance and show your Energy configuration panel.](https://my.home-assistant.io/badges/config_energy.svg)](https://my.home-assistant.io/redirect/config_energy/)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Once you've authenticated, the integration will automatically set up the followi
 - Standing Charge - Current standing charge (GBP)
 - Rate - Current tariff (GBP/kWh)
 
-The usage and cost sensors will still show the previous day's data until shortly after 01:30 to ensure that all of the previous day's data is collected.
+The usage and cost sensors will still show the previous day's data until shortly after 01:00 to ensure that all of the previous day's data is collected.
 
 The standing charge and rate sensors are disabled by default as they are less commonly used. Before enabling them, ensure the data is visible in the Bright app.
 
@@ -60,6 +60,7 @@ If the data being shown is wrong, check the Bright app first. If it is also wron
 
 The sensors created integrate directly into Home Assistant's [Home Energy Management](https://www.home-assistant.io/docs/energy/).
 It is recommended you use the daily usage and cost sensors in the Energy integration.
+However, be aware that due to the lower refresh rate of this Integration, you will need to wait until the sensors have data, before you can add/edit them into the Energy dashboard (they will have an indepterminate state before that) - so wait an hour or two.
 
 [![Open your Home Assistant instance and show your Energy configuration panel.](https://my.home-assistant.io/badges/config_energy.svg)](https://my.home-assistant.io/redirect/config_energy/)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The original from (HandyHat) of this project is now declared as abandoned, so af
 
 You can install this component through [HACS](https://hacs.xyz/) to easily receive updates. Once HACS is installed, click this link:
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=HandyHat&repository=ha-hildebrandglow-dcc)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Jonandel&repository=ha-hildebrandglow-dcc)
 
 <details>
   <summary>Manually add to HACS</summary>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Hildebrand Glow (DCC) Integration
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
-[![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/JonandEl/ha-hildebrandglow-dcc?style=for-the-badge)](https://www.codefactor.io/repository/github/handyhat/ha-hildebrandglow-dcc)
-[![DeepSource](https://deepsource.io/gh/HandyHat/ha-hildebrandglow-dcc.svg/?label=active+issues&show_trend=true&token=gYN6CNb5ApHN5Pry_U-FFSYK)](https://deepsource.io/gh/JonandEl/ha-hildebrandglow-dcc/?ref=repository-badge)
+[![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/JonandEl/ha-hildebrandglow-dcc?style=for-the-badge)](https://www.codefactor.io/repository/github/jonandel/ha-hildebrandglow-dcc)
+[![DeepSource](https://deepsource.io/gh/jonandel/ha-hildebrandglow-dcc.svg/?label=active+issues&show_trend=true&token=gYN6CNb5ApHN5Pry_U-FFSYK)](https://deepsource.io/gh/JonandEl/ha-hildebrandglow-dcc/?ref=repository-badge)
 [!["Buy the original author A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/HandyHat)
 
 Home Assistant integration for energy consumption data from UK SMETS (Smart) meters using the Hildebrand Glow API.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/HandyHat)
 
 Home Assistant integration for energy consumption data from UK SMETS (Smart) meters using the Hildebrand Glow API.
-
-The original of this project is now declared as abandoned, so after the local tweaks Ive been making over the last 24 months, and into the future, I decided to create my own fork.
+The original from (HandyHat) of this project is now declared as abandoned, so after the local tweaks Ive been making over the last 24 months, and into the future, I decided to create my own fork.
 
 ## Installation
 

--- a/custom_components/hildebrandglow_dcc/__init__.py
+++ b/custom_components/hildebrandglow_dcc/__init__.py
@@ -1,4 +1,5 @@
 """The Hildebrand Glow (DCC) integration."""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/hildebrandglow_dcc/config_flow.py
+++ b/custom_components/hildebrandglow_dcc/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Hildebrand Glow (DCC) integration."""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/hildebrandglow_dcc/const.py
+++ b/custom_components/hildebrandglow_dcc/const.py
@@ -1,3 +1,13 @@
 """Constants for the Hildebrand Glow (DCC) integration."""
 
 DOMAIN = "hildebrandglow_dcc"
+
+# Virtual Entity Classifiers
+ELEC_CONSUMPTION_CLASSIFIER = "electricity.consumption"
+GAS_CONSUMPTION_CLASSIFIER = "gas.consumption"
+ELEC_COST_CLASSIFIER = "electricity.consumption.cost"
+GAS_COST_CLASSIFIER = "gas.consumption.cost"
+
+# Device Types
+ELECTRIC_METER = "electric_meter"
+GAS_METER = "gas_meter"

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pyglowmarkt==0.5.5"
   ],
-  "version": "1.0.3"
+  "version": "1.0.4"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pyglowmarkt==0.5.6"
   ],
-  "version": "1.0.2-beta"
+  "version": "1.1.0"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pyglowmarkt==0.5.5"
   ],
-  "version": "1.0.4"
+  "version": "1.1.0"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pyglowmarkt==0.5.6"
   ],
-  "version": "1.1.0"
+  "version": "1.1.5"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -2,7 +2,7 @@
   "domain": "hildebrandglow_dcc",
   "name": "Hildebrand Glow (DCC)",
   "codeowners": [
-    "@HandyHat"
+    "@JonandEl"
   ],
   "config_flow": true,
   "documentation": "https://github.com/jonandel/ha-hildebrandglow-dcc",

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pyglowmarkt==0.5.5"
   ],
-  "version": "1.0.1-beta"
+  "version": "1.0.2-beta"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jonandel/ha-hildebrandglow-dcc/issues",
   "requirements": [
-    "pyglowmarkt==0.5.5"
+    "pyglowmarkt==0.5.6"
   ],
   "version": "1.0.2-beta"
 }

--- a/custom_components/hildebrandglow_dcc/manifest.json
+++ b/custom_components/hildebrandglow_dcc/manifest.json
@@ -5,12 +5,12 @@
     "@HandyHat"
   ],
   "config_flow": true,
-  "documentation": "https://github.com/HandyHat/ha-hildebrandglow-dcc",
+  "documentation": "https://github.com/jonandel/ha-hildebrandglow-dcc",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/HandyHat/ha-hildebrandglow-dcc/issues",
+  "issue_tracker": "https://github.com/jonandel/ha-hildebrandglow-dcc/issues",
   "requirements": [
     "pyglowmarkt==0.5.5"
   ],
-  "version": "1.1.0"
+  "version": "1.0.1-beta"
 }

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -124,7 +124,7 @@ def supply_type(resource) -> str:
         return "electricity"
     if "gas.consumption" in resource.classifier:
         return "gas"
-    _LOGGER.error("Unknown classifier: %s. Please open an issue", resource.classifier)
+        _LOGGER.error("Unknown classifier: %s. Please open an issue", resource.classifier)
     return "unknown"
 
 

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -151,19 +151,6 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
     """Get daily usage from the API."""
     # If it's before 01:06, we need to fetch yesterday's data
     # Should only need to be before 00:36 but gas data can be 30 minutes behind electricity data
-    #if datetime.now(tz).time() <= time(1, 5):
-    #    _LOGGER.debug("Fetching yesterday's data")
-    #    now = datetime.now(tz) - timedelta(days=1)
-    #else:
-    #    now = datetime.now(tz)
-    # Use Jons idea to ask for sum for entire day each time.
-    #todaystart = datetime.combine(datetime.today(), time.min)
-    #endoftoday = todaystart + timedelta(hours=23) + timedelta(minutes=59)
-    # Round to the day to set time to 00:00:00
-    #t_from = await hass.async_add_executor_job(resource.round, todaystart, "P1D")
-    # Round to the minute
-    #t_to = await hass.async_add_executor_job(resource.round, endoftoday, "PT1M")
-    #_LOGGER.debug("To %s and From %s", t_to, t_from)
     if datetime.now(tz).time() <= time(1, 5):
         _LOGGER.debug("Fetching yesterday's data")
         now = datetime.now(tz) - timedelta(days=1)

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -188,7 +188,7 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
             resource.get_readings, t_from, t_to, "P1D", "sum", True
         )
         _LOGGER.debug("Successfully got daily usage for resource id %s", resource.id)
-        #Using the new logic above, there should only ever be one reading (not two, where the days > 1 based upon times)
+        # Using the new logic above, there should only ever be one reading (not two, where the days > 1 based upon times), but there is, and there are also time there are zero returns (just after midnight)
         _LOGGER.debug("Readings for %s has %s entries", resource.classifier, len(readings))
         if len(readings) == 0:
             v = 0

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -165,7 +165,7 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
         else:
             _LOGGER.exception("Unexpected exception: %s. Please open an issue", ex)
     # Round to the day to set time to 00:00:00, but taking off the UTC offset if there is one.
-    #Use this strategy, to get the last hour(s) before midnight as well, as our day starts utc_offset from UTC
+    # Use this strategy, to get the last hour(s) before midnight as well, as our day starts utc_offset from UTC
     t_from = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(minutes=utc_offset)
     # Round the now (in UTC) to the minute
     t_to = now.replace(second=0, microsecond=0)
@@ -185,8 +185,7 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
         _LOGGER.debug(
             "Readings for %s has %s entries", resource.classifier, len(readings)
         )
-        if not readings:   #Check if we get no return values
-            v = 0  # Return zero value.
+        if not readings:   #Check if we get zero return values
             _LOGGER.debug("nothing returned")
         else:
             v = readings[0][1].value
@@ -196,15 +195,16 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
                 readings[0][0],
                 readings[0][1].value,
             )
-        if len(readings) > 1:
-            v += readings[1][1].value
-            _LOGGER.debug(
-                "%s Second reading %s at %s",
-                resource.classifier,
-                readings[1][0],
-                readings[1][1].value,
-            )
-        return v
+            if len(readings) > 1:
+                v += readings[1][1].value
+                _LOGGER.debug(
+                    "%s Second reading %s at %s",
+                    resource.classifier,
+                    readings[1][0],
+                    readings[1][1].value,
+                )
+            # only return a value, if one or more values came back from the API.
+            return v
     except requests.Timeout as ex:
         _LOGGER.error("Timeout: %s", ex)
     except requests.exceptions.ConnectionError as ex:

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -28,7 +28,7 @@ from homeassistant.util import dt as dt_util
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-SCAN_INTERVAL = timedelta(minutes=15)
+SCAN_INTERVAL = timedelta(minutes=10)
 
 # --- COORDINATOR CLASSES ---
 
@@ -161,9 +161,11 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
         else:
             _LOGGER.exception("Unexpected exception: %s. Please open an issue", ex)
     # Round to the day to set time to 00:00:00 using the executor job.
-    t_from = await hass.async_add_executor_job(resource.round, now, "P1D")
+    #t_from = await hass.async_add_executor_job(resource.round, now, "P1D")
+    t_from = now.replace(hour=0, minute=0, second=0, microsecond=0)
     # Round the now (in UTC) to the minute
-    t_to = await hass.async_add_executor_job(resource.round, now, "PT1M")
+    #t_to = await hass.async_add_executor_job(resource.round, now, "PT1M")
+    t_to = now.replace(second=0, microsecond=0)
     # define the number of minutes to request the data offset, as described in the API for data, to account for differences to UTC
     # Note: offset is how many minutes behind UTC we are.
     utc_offset = -int(dt_util.now().utcoffset().total_seconds() / 60)
@@ -185,8 +187,8 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
             "Readings for %s has %s entries", resource.classifier, len(readings)
         )
         if len(readings) == 0:
-            v = 0
-            _LOGGER.debug("setting sensor value to zero")
+            #v = 0  Dont set return value.
+            _LOGGER.debug("nothing returned")
         else:
             v = readings[0][1].value
             _LOGGER.debug(

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -29,6 +29,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(minutes=15)
+TARIFF_SCAN_INTERVAL = timedelta(minutes=60)
 
 # --- COORDINATOR CLASSES ---
 
@@ -83,9 +84,7 @@ class TariffCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=f"Tariff Data {resource.classifier}",  # More specific name for logging
-            update_interval=timedelta(
-                minutes=60
-            ),  # Or your desired tariff update interval
+            update_interval=TARIFF_SCAN_INTERVAL,
         )
         self.resource = resource
 

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -166,7 +166,9 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
             _LOGGER.exception("Unexpected exception: %s. Please open an issue", ex)
     # Round to the day to set time to 00:00:00, but taking off the UTC offset if there is one.
     # Use this strategy, to get the last hour(s) before midnight as well, as our day starts utc_offset from UTC
-    t_from = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(minutes=utc_offset)
+    t_from = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
+        minutes=utc_offset
+    )
     # Round the now (in UTC) to the minute
     t_to = now.replace(second=0, microsecond=0)
 
@@ -185,7 +187,7 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
         _LOGGER.debug(
             "Readings for %s has %s entries", resource.classifier, len(readings)
         )
-        if not readings:   #Check if we get zero return values
+        if not readings:  # Check if we get zero return values
             _LOGGER.debug("nothing returned")
         else:
             v = readings[0][1].value

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -161,10 +161,10 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
         else:
             _LOGGER.exception("Unexpected exception: %s. Please open an issue", ex)
     # Round to the day to set time to 00:00:00 using the executor job.
-    #t_from = await hass.async_add_executor_job(resource.round, now, "P1D")
+    # t_from = await hass.async_add_executor_job(resource.round, now, "P1D")
     t_from = now.replace(hour=0, minute=0, second=0, microsecond=0)
     # Round the now (in UTC) to the minute
-    #t_to = await hass.async_add_executor_job(resource.round, now, "PT1M")
+    # t_to = await hass.async_add_executor_job(resource.round, now, "PT1M")
     t_to = now.replace(second=0, microsecond=0)
     # define the number of minutes to request the data offset, as described in the API for data, to account for differences to UTC
     # Note: offset is how many minutes behind UTC we are.
@@ -187,7 +187,7 @@ async def daily_data(hass: HomeAssistant, resource) -> float:
             "Readings for %s has %s entries", resource.classifier, len(readings)
         )
         if len(readings) == 0:
-            #v = 0  Dont set return value.
+            # v = 0  Dont set return value.
             _LOGGER.debug("nothing returned")
         else:
             v = readings[0][1].value

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
     "name": "Hildebrand Glow (DCC)",
     "render_readme": true,
     "country": ["GB"],
-    "homeassistant": "2022.12.0"
+    "homeassistant": "2025.6.0"
   }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black==23.9.1
 homeassistant
 isort==5.12.0
-pyglowmarkt==0.5.5
+pyglowmarkt==0.5.6
 pylint==2.17.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ black==23.9.1
 homeassistant
 isort==5.12.0
 pyglowmarkt==0.5.6
-pylint==2.17.4
+pylint==3.3.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==23.9.1
+black==25.1.0
 homeassistant
 isort==5.12.0
 pyglowmarkt==0.5.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black==23.9.1
 homeassistant
-isort==5.12.0
+isort==6.0.1
 pyglowmarkt==0.5.6
 pylint==3.3.7


### PR DESCRIPTION
I have created a branch (tentatively called v1.1.5 when released) that has a more robust setup when the integration starts.

It (deliberately) creates the hub and sensors, and reports that as success (or failure) once loaded - so for folks who werent seeing sensors (because one of them failed in attempting to grab the data) - this wont happen anymore.

It does mean that the sensors will be listed in the Integration page, as soon as authentication and setup is successful - but they will be immediately 'unavailable' until the data is successfully pulled, and HA considers the sensor 'stable'.  Typically two pull cycles - ie 30 mins.
Note the rate and standing tarrifs are every hour - and by default are switched off (as per the original integration). so will be unavailable for longer if they are enabled and configured by your energy provider(s).